### PR TITLE
fix(@angular/cli): allow tslint to find the appropriate config (#5792)

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -232,8 +232,7 @@
           },
           "tslintConfig": {
             "description": "Location of the tslint.json configuration.",
-            "type": "string",
-            "default": "tslint.json"
+            "type": "string"
           },
           "exclude": {
             "description": "File glob(s) to ignore.",

--- a/tests/e2e/tests/lint/lint-with-nested-configs.ts
+++ b/tests/e2e/tests/lint/lint-with-nested-configs.ts
@@ -1,0 +1,23 @@
+import { createDir, writeFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
+
+export default function () {
+  const fileName = 'src/app/foo/foo.ts';
+  const nestedConfigContent = `
+  {
+    "rules": {
+      "quotemark": [
+        true,
+        "double",
+        "avoid-escape"
+      ]
+    }
+  }`;
+
+  return Promise.resolve()
+    .then(() => createDir('src/app/foo'))
+    .then(() => writeFile(fileName, 'const foo = \'\';\n'))
+    .then(() => writeFile('src/app/foo/tslint.json', nestedConfigContent))
+    .then(() => expectToFail(() => ng('lint')));
+}


### PR DESCRIPTION
TSLint includes logic to find the most relevant config per linted file. Unfortunately, by defaulting the config filename this behavior was being disabled.

Fixes #5770