### PR TITLE
Update upstream build: pin zone.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "webpack-dev-middleware": "^1.11.0",
     "webpack-dev-server": "~2.5.1",
     "webpack-merge": "^2.4.0",
-    "zone.js": "^0.8.4"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "@angular/compiler": "^4.0.0",

--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -26,7 +26,7 @@
     "@angular/router": "^4.2.4",
     "core-js": "^2.4.1",
     "rxjs": "^5.4.1",
-    "zone.js": "^0.8.12"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "@angular/cli": "<%= version %>",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -86,7 +86,7 @@
     "webpack-dev-middleware": "^1.11.0",
     "webpack-dev-server": "~2.4.5",
     "webpack-merge": "^2.4.0",
-    "zone.js": "^0.8.4"
+    "zone.js": "0.8.12"
   },
   "optionalDependencies": {
     "node-sass": "^4.3.0"

--- a/tests/e2e/assets/1.0.0-proj/package.json
+++ b/tests/e2e/assets/1.0.0-proj/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "^4.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.1.0",
-    "zone.js": "^0.8.4"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "@angular/cli": "1.0.0",

--- a/tests/e2e/assets/webpack/test-app-weird/package.json
+++ b/tests/e2e/assets/webpack/test-app-weird/package.json
@@ -14,7 +14,7 @@
     "@ngtools/webpack": "0.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.0.1",
-    "zone.js": "^0.7.2"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "node-sass": "^3.7.0",

--- a/tests/e2e/assets/webpack/test-app/package.json
+++ b/tests/e2e/assets/webpack/test-app/package.json
@@ -14,7 +14,7 @@
     "@ngtools/webpack": "0.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.0.1",
-    "zone.js": "^0.7.2"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "node-sass": "^3.7.0",

--- a/tests/e2e/assets/webpack/test-server-app/package.json
+++ b/tests/e2e/assets/webpack/test-server-app/package.json
@@ -15,7 +15,7 @@
     "@ngtools/webpack": "0.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.3.1",
-    "zone.js": "^0.8.10"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "node-sass": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5655,6 +5655,6 @@ yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
 
-zone.js@^0.8.4:
+zone.js@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.12.tgz#86ff5053c98aec291a0bf4bbac501d694a05cfbb"


### PR DESCRIPTION
`zone.js@0.8.13` has some bugs that break our CI runs. These are being tracked in https://github.com/angular/zone.js/issues/832.

Until a these are fixed and a new versions is released, we should pin to `zone.js@0.8.12`. Another PR should go up then and unpin to `zone.js@^0.8.14`.