### PR TITLE
Update upstream

### DIFF
--- a/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json
+++ b/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/lib",
     "target": "es2015",
+    "module": "es2015",
     "moduleResolution": "node",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
When not specified the `commonjs` will be used which will cause erros when consuming the library `Module not found: Error: Can't resolve ' commonjs-proxy:../file`

https://github.com/dherges/ng-packagr/issues/944

Closes #11255