### PR TITLE
destroy injector when module is destroyed

### DIFF
--- a/packages/angular_devkit/core/node/cli-logger.ts
+++ b/packages/angular_devkit/core/node/cli-logger.ts
@@ -25,19 +25,19 @@ export function createConsoleLogger(
   logger
     .pipe(filter(entry => (entry.level != 'debug' || verbose)))
     .subscribe(entry => {
-      let color: (s: string) => string = x => terminal.dim(terminal.white(x));
+      let color = terminal.dim;
       let output = stdout;
       switch (entry.level) {
         case 'info':
-          color = terminal.white;
+          color = terminal.reset;
           break;
         case 'warn':
-          color = (x: string) => terminal.bold(terminal.yellow(x));
+          color = (s: string) => terminal.bold(terminal.yellow(s));
           output = stderr;
           break;
         case 'fatal':
         case 'error':
-          color = (x: string) => terminal.bold(terminal.red(x));
+          color = (s: string) => terminal.bold(terminal.red(s));
           output = stderr;
           break;
       }


### PR DESCRIPTION
…ault colors

Previously, we set the color to white, which is (nearly) invisible on
terminals with a white background.

Fixes #13439.