### PR TITLE
bug fix on the server

### DIFF
--- a/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
+++ b/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
@@ -69,7 +69,6 @@ export function countOccurrences(source: string, match: string, wordBreak = fals
  * Holder of statistics related to the build.
  */
 class AnalyticsBuildStats {
-  public isIvy = false;
   public errors: string[] = [];
   public numberOfNgOnInit = 0;
   public numberOfComponents = 0;
@@ -96,7 +95,9 @@ export class NgBuildAnalyticsPlugin {
     protected _projectRoot: string,
     protected _analytics: analytics.Analytics,
     protected _category: string,
-  ) {}
+    private _isIvy: boolean,
+  ) {
+  }
 
   protected _reset() {
     this._stats = new AnalyticsBuildStats();
@@ -129,7 +130,7 @@ export class NgBuildAnalyticsPlugin {
       dimensions[analytics.NgCliAnalyticsDimensions.BuildErrors] = `,${this._stats.errors.join()},`;
     }
 
-    dimensions[analytics.NgCliAnalyticsDimensions.NgIvyEnabled] = this._stats.isIvy;
+    dimensions[analytics.NgCliAnalyticsDimensions.NgIvyEnabled] = this._isIvy;
 
     return dimensions;
   }
@@ -159,13 +160,7 @@ export class NgBuildAnalyticsPlugin {
       // This does not include View Engine AOT compilation, we use the ngfactory for it.
       this._stats.numberOfComponents += countOccurrences(module._source.source(), ' Component({');
       // For Ivy we just count ɵcmp.
-      const numIvyComponents = countOccurrences(module._source.source(), 'ɵcmp', true);
-      this._stats.numberOfComponents += numIvyComponents;
-
-      // Check whether this is an Ivy app so that it can reported as part of analytics.
-      if (!this._stats.isIvy && numIvyComponents > 0) {
-        this._stats.isIvy = true;
-      }
+      this._stats.numberOfComponents += countOccurrences(module._source.source(), '.ɵcmp', true);
     }
   }
 

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -166,7 +166,12 @@ function getAnalyticsConfig(
 
     // The category is the builder name if it's an angular builder.
     return {
-      plugins: [new NgBuildAnalyticsPlugin(wco.projectRoot, context.analytics, category)],
+      plugins: [new NgBuildAnalyticsPlugin(
+        wco.projectRoot,
+        context.analytics,
+        category,
+        !!wco.tsConfig.options.enableIvy,
+      )],
     };
   }
 


### PR DESCRIPTION
… enableIvy

At the moment we are relying on source content to determine if the compilation is under Ivy or VE. However, we do know what compilation we are in from the parsed tsconfig.

With this change we use the `enableIvy` to set the analytics metric