### PR TITLE
Create a new pull request by comparing changes

### DIFF
--- a/packages/angular/cli/commands/doc-impl.ts
+++ b/packages/angular/cli/commands/doc-impl.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as open from 'open';
+import open from 'open';
 import { Command } from '../models/command';
 import { Arguments } from '../models/interface';
 import { Schema as DocCommandSchema } from './doc';

--- a/packages/angular/cli/models/analytics-collector.ts
+++ b/packages/angular/cli/models/analytics-collector.ts
@@ -8,7 +8,7 @@
 
 import { analytics } from '@angular-devkit/core';
 import { execSync } from 'child_process';
-import * as debug from 'debug';
+import debug from 'debug';
 import * as https from 'https';
 import * as os from 'os';
 import * as querystring from 'querystring';

--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -7,7 +7,7 @@
  */
 
 import { json, tags } from '@angular-devkit/core';
-import * as debug from 'debug';
+import debug from 'debug';
 import * as inquirer from 'inquirer';
 import { v4 as uuidV4 } from 'uuid';
 import { colors } from '../utilities/color';
@@ -298,9 +298,8 @@ export async function getWorkspaceAnalytics(): Promise<AnalyticsCollector | unde
   analyticsDebug('getWorkspaceAnalytics');
   try {
     const globalWorkspace = await getWorkspace('local');
-    const analyticsConfig: string | undefined | null | { uid?: string } = globalWorkspace?.getCli()[
-      'analytics'
-    ];
+    const analyticsConfig: string | undefined | null | { uid?: string } =
+      globalWorkspace?.getCli()['analytics'];
     analyticsDebug('Workspace Analytics config found: %j', analyticsConfig);
 
     if (analyticsConfig === false) {

--- a/packages/angular/cli/utilities/spinner.ts
+++ b/packages/angular/cli/utilities/spinner.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ora from 'ora';
+import ora from 'ora';
 import { colors } from './color';
 
 export class Spinner {

--- a/packages/angular/pwa/pwa/index.ts
+++ b/packages/angular/pwa/pwa/index.ts
@@ -30,7 +30,7 @@ function updateIndexFile(path: string): Rule {
       throw new SchematicsException(`Could not read index file: ${path}`);
     }
 
-    const rewriter = new (await import('parse5-html-rewriting-stream'))();
+    const rewriter = new (await import('parse5-html-rewriting-stream')).default();
     let needsNoScript = true;
     rewriter.on('startTag', (startTag) => {
       if (startTag.tagName === 'noscript') {

--- a/packages/angular_devkit/architect/node/node-modules-architect-host.ts
+++ b/packages/angular_devkit/architect/node/node-modules-architect-host.ts
@@ -91,12 +91,12 @@ export class WorkspaceNodeModulesArchitectHost implements ArchitectHost<NodeModu
             throw new Error(`Project "${project}" does not exist.`);
           }
 
-          return ({
+          return {
             root: projectDefinition.root,
             sourceRoot: projectDefinition.sourceRoot,
             prefix: projectDefinition.prefix,
             ...(clone(projectDefinition.extensions) as {}),
-          } as unknown) as json.JsonObject;
+          } as unknown as json.JsonObject;
         },
         async hasTarget(project, target) {
           return !!workspaceOrHost.projects.get(project)?.targets.has(target);
@@ -199,6 +199,11 @@ export class WorkspaceNodeModulesArchitectHost implements ArchitectHost<NodeModu
     const builder = (await import(info.import)).default;
     if (builder[BuilderSymbol]) {
       return builder;
+    }
+
+    // Default handling code is for old builders that incorrectly export `default` with non-ESM module
+    if (builder?.default[BuilderSymbol]) {
+      return builder.default;
     }
 
     throw new Error('Builder is not a builder');

--- a/packages/angular_devkit/architect_cli/bin/architect.ts
+++ b/packages/angular_devkit/architect_cli/bin/architect.ts
@@ -13,7 +13,7 @@ import { logging, schema, tags, workspaces } from '@angular-devkit/core';
 import { NodeJsSyncHost, createConsoleLogger } from '@angular-devkit/core/node';
 import * as ansiColors from 'ansi-colors';
 import { existsSync } from 'fs';
-import * as minimist from 'minimist';
+import minimist from 'minimist';
 import * as path from 'path';
 import { tap } from 'rxjs/operators';
 import { MultiProgressBar } from '../src/progress';

--- a/packages/angular_devkit/architect_cli/src/progress.ts
+++ b/packages/angular_devkit/architect_cli/src/progress.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ProgressBar from 'progress';
+import ProgressBar from 'progress';
 import * as readline from 'readline';
 
 export class MultiProgressBar<Key, T> {

--- a/packages/angular_devkit/benchmark/src/main.ts
+++ b/packages/angular_devkit/benchmark/src/main.ts
@@ -11,7 +11,7 @@ import { logging, tags } from '@angular-devkit/core';
 import { ProcessOutput } from '@angular-devkit/core/node';
 import * as ansiColors from 'ansi-colors';
 import { appendFileSync, writeFileSync } from 'fs';
-import * as minimist from 'minimist';
+import minimist from 'minimist';
 import { filter, map, toArray } from 'rxjs/operators';
 import { Command } from '../src/command';
 import { defaultReporter } from '../src/default-reporter';
@@ -73,7 +73,7 @@ export async function main({
   }
 
   // Parse the command line.
-  const argv = (minimist(args, {
+  const argv = minimist(args, {
     boolean: ['help', 'verbose', 'overwrite-output-file'],
     string: ['watch-matcher', 'watch-script'],
     default: {
@@ -86,7 +86,7 @@ export async function main({
       'watch-timeout': 10000,
     },
     '--': true,
-  }) as {}) as BenchmarkCliArgv;
+  }) as {} as BenchmarkCliArgv;
 
   // Create the DevKit Logger used through the CLI.
   const logger = new logging.TransformLogger('benchmark-prefix-logger', (stream) =>

--- a/packages/angular_devkit/benchmark/src/monitored-process.ts
+++ b/packages/angular_devkit/benchmark/src/monitored-process.ts
@@ -7,7 +7,7 @@
  */
 
 import { SpawnOptions, spawn } from 'child_process';
-import * as pidusage from 'pidusage';
+import pidusage from 'pidusage';
 import { Observable, Subject, from, timer } from 'rxjs';
 import { concatMap, map, onErrorResumeNext, tap } from 'rxjs/operators';
 import { Command } from './command';

--- a/packages/angular_devkit/build_angular/src/app-shell/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/app-shell/app-shell_spec.ts
@@ -8,7 +8,7 @@
 
 import { Architect } from '@angular-devkit/architect';
 import { getSystemPath, join, normalize, virtualFs } from '@angular-devkit/core';
-import * as express from 'express'; // eslint-disable-line import/no-extraneous-dependencies
+import express from 'express'; // eslint-disable-line import/no-extraneous-dependencies
 import * as http from 'http';
 import { AddressInfo } from 'net';
 import { createArchitect, host } from '../test-utils';

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { Observable, from } from 'rxjs';
 import { concatMap, map, switchMap } from 'rxjs/operators';
 import { ScriptTarget } from 'typescript';
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 import { ExecutionTransformer } from '../transforms';
 import {
   BuildBrowserFeatures,

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -18,8 +18,8 @@ import { Observable, from } from 'rxjs';
 import { concatMap, switchMap } from 'rxjs/operators';
 import * as ts from 'typescript';
 import * as url from 'url';
-import * as webpack from 'webpack';
-import * as webpackDevServer from 'webpack-dev-server';
+import webpack from 'webpack';
+import webpackDevServer from 'webpack-dev-server';
 import { Schema as BrowserBuilderSchema, OutputHashing } from '../browser/schema';
 import { ExecutionTransformer } from '../transforms';
 import { BuildBrowserFeatures, normalizeOptimization } from '../utils';
@@ -362,7 +362,7 @@ export function serveWebpackBrowser(
             );
 
             if (options.open) {
-              const open = await import('open');
+              const open = (await import('open')).default;
               await open(serverAddress);
             }
           }

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -13,7 +13,7 @@ import type { ɵParsedMessage as LocalizeMessage } from '@angular/localize';
 import type { Diagnostics } from '@angular/localize/src/tools/src/diagnostics';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 import { Schema as BrowserBuilderOptions, OutputHashing } from '../browser/schema';
 import { ExecutionTransformer } from '../transforms';
 import { createI18nOptions } from '../utils/i18n-options';

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import { Observable, from } from 'rxjs';
 import { concatMap, map } from 'rxjs/operators';
 import { ScriptTarget } from 'typescript';
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 import { ExecutionTransformer } from '../transforms';
 import { NormalizedBrowserBuilderSchema, deleteOutputDir } from '../utils';
 import { i18nInlineEmittedFiles } from '../utils/i18n-inlining';

--- a/packages/angular_devkit/build_angular/src/utils/build-browser-features.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-browser-features.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as browserslist from 'browserslist';
+import browserslist from 'browserslist';
 import { feature, features } from 'caniuse-lite';
 import * as ts from 'typescript';
 

--- a/packages/angular_devkit/build_angular/src/utils/cache-path.ts
+++ b/packages/angular_devkit/build_angular/src/utils/cache-path.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as findCacheDirectory from 'find-cache-dir';
+import findCacheDirectory from 'find-cache-dir';
 import { tmpdir } from 'os';
 import { resolve } from 'path';
 import { cachingBasePath } from './environment-options';

--- a/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
+++ b/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
@@ -7,7 +7,7 @@
  */
 
 import * as fs from 'fs';
-import * as glob from 'glob';
+import glob from 'glob';
 import * as path from 'path';
 import { copyFile } from './copy-file';
 

--- a/packages/angular_devkit/build_angular/src/utils/index-file/html-rewriting-stream.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/html-rewriting-stream.ts
@@ -8,14 +8,12 @@
 
 import { Readable, Writable } from 'stream';
 
-export async function htmlRewritingStream(
-  content: string,
-): Promise<{
+export async function htmlRewritingStream(content: string): Promise<{
   rewriter: import('parse5-html-rewriting-stream');
   transformedContent: Promise<string>;
 }> {
   const chunks: Buffer[] = [];
-  const rewriter = new (await import('parse5-html-rewriting-stream'))();
+  const rewriter = new (await import('parse5-html-rewriting-stream')).default();
 
   return {
     rewriter,

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -9,7 +9,7 @@
 import * as cacache from 'cacache';
 import * as fs from 'fs';
 import * as https from 'https';
-import * as proxyAgent from 'https-proxy-agent';
+import proxyAgent from 'https-proxy-agent';
 import { URL } from 'url';
 import { findCachePath } from '../cache-path';
 import { cachingDisabled } from '../environment-options';

--- a/packages/angular_devkit/build_angular/src/utils/spinner.ts
+++ b/packages/angular_devkit/build_angular/src/utils/spinner.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ora from 'ora';
+import ora from 'ora';
 import { colors } from './color';
 import { isTTY } from './tty';
 

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -15,7 +15,7 @@ import {
   GLOBAL_DEFS_FOR_TERSER_WITH_AOT,
   VERSION as NG_VERSION,
 } from '@angular/compiler-cli';
-import * as CopyWebpackPlugin from 'copy-webpack-plugin';
+import CopyWebpackPlugin from 'copy-webpack-plugin';
 import { createHash } from 'crypto';
 import { createWriteStream, existsSync, promises as fsPromises } from 'fs';
 import * as path from 'path';

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
@@ -11,7 +11,7 @@
 import * as http from 'http';
 import * as path from 'path';
 import * as glob from 'glob';
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 const webpackDevMiddleware = require('webpack-dev-middleware');
 
 import { statsErrorsToString } from '../../utils/stats';

--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -9,7 +9,7 @@
 import { WebpackLoggingCallback } from '@angular-devkit/build-webpack';
 import { logging, tags } from '@angular-devkit/core';
 import * as path from 'path';
-import * as textTable from 'text-table';
+import textTable from 'text-table';
 import { Configuration, StatsCompilation } from 'webpack';
 import { Schema as BrowserBuilderOptions } from '../../browser/schema';
 import { colors as ansiColors, removeColor } from '../../utils/color';

--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/index.ts
@@ -11,8 +11,8 @@ import * as net from 'net';
 import { resolve as pathResolve } from 'path';
 import { Observable, from, isObservable, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
-import * as webpack from 'webpack';
-import * as WebpackDevServer from 'webpack-dev-server';
+import webpack from 'webpack';
+import WebpackDevServer from 'webpack-dev-server';
 import { getEmittedFiles } from '../utils';
 import { BuildResult, WebpackFactory, WebpackLoggingCallback } from '../webpack';
 import { Schema as WebpackDevServerBuilderSchema } from './schema';
@@ -85,12 +85,12 @@ export function runWebpackDevServer(
             // Log stats.
             log(stats, config);
 
-            obs.next(({
+            obs.next({
               ...result,
               emittedFiles: getEmittedFiles(stats.compilation),
               success: !stats.hasErrors(),
               outputPath: stats.compilation.outputOptions.path,
-            } as unknown) as DevServerBuildOutput);
+            } as unknown as DevServerBuildOutput);
           });
 
           server.listen(
@@ -132,7 +132,9 @@ export default createBuilder<WebpackDevServerBuilderSchema, DevServerBuildOutput
     const configPath = pathResolve(context.workspaceRoot, options.webpackConfig);
 
     return from(import(configPath)).pipe(
-      switchMap((config: webpack.Configuration) => runWebpackDevServer(config, context)),
+      switchMap(({ default: config }: { default: webpack.Configuration }) =>
+        runWebpackDevServer(config, context),
+      ),
     );
   },
 );

--- a/packages/angular_devkit/build_webpack/src/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index.ts
@@ -10,7 +10,7 @@ import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/ar
 import { resolve as pathResolve } from 'path';
 import { Observable, from, isObservable, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 import { EmittedFiles, getEmittedFiles } from '../utils';
 import { Schema as RealWebpackBuilderSchema } from './schema';
 
@@ -115,6 +115,8 @@ export default createBuilder<WebpackBuilderSchema>((options, context) => {
   const configPath = pathResolve(context.workspaceRoot, options.webpackConfig);
 
   return from(import(configPath)).pipe(
-    switchMap((config: webpack.Configuration) => runWebpack(config, context)),
+    switchMap(({ default: config }: { default: webpack.Configuration }) =>
+      runWebpack(config, context),
+    ),
   );
 });

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -8,7 +8,7 @@
 
 import { BaseException } from '@angular-devkit/core';
 import { SpawnOptions, spawn } from 'child_process';
-import * as ora from 'ora';
+import ora from 'ora';
 import * as path from 'path';
 import { Observable } from 'rxjs';
 import { TaskExecutor, UnsuccessfulWorkflowExecution } from '../../src';

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host.ts
@@ -105,7 +105,8 @@ export class FileSystemEngineHost extends FileSystemEngineHostBase {
       try {
         const path = require.resolve(join(this._root, name));
 
-        return from(import(path).then((mod) => mod.default())).pipe(
+        // Default handling code is for old tasks that incorrectly export `default` with non-ESM module
+        return from(import(path).then((mod) => (mod.default?.default || mod.default)())).pipe(
           catchError(() => throwError(new UnregisteredTaskException(name))),
         );
       } catch {}

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -15,7 +15,7 @@ import { UnsuccessfulWorkflowExecution } from '@angular-devkit/schematics';
 import { NodeWorkflow } from '@angular-devkit/schematics/tools';
 import * as ansiColors from 'ansi-colors';
 import * as inquirer from 'inquirer';
-import * as minimist from 'minimist';
+import minimist from 'minimist';
 
 /**
  * Parse the name of schematic passed in argument, and return a {collection, schematic} named

--- a/packages/schematics/angular/migrations/update-10/remove-es5-browser-support.ts
+++ b/packages/schematics/angular/migrations/update-10/remove-es5-browser-support.ts
@@ -113,7 +113,7 @@ async function isES5SupportNeeded(projectRoot: Path): Promise<boolean | undefine
 
   try {
     // eslint-disable-next-line import/no-extraneous-dependencies
-    const browserslist = await import('browserslist');
+    const browserslist = (await import('browserslist')).default;
     const supportedBrowsers = browserslist(undefined, {
       path: getSystemPath(projectRoot),
     });

--- a/scripts/build-schema.ts
+++ b/scripts/build-schema.ts
@@ -8,7 +8,7 @@
 
 import { logging } from '@angular-devkit/core';
 import * as fs from 'fs';
-import * as glob from 'glob';
+import glob from 'glob';
 import * as path from 'path';
 
 export default async function (argv: {}, logger: logging.Logger) {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -9,7 +9,7 @@
 import { JsonObject, logging } from '@angular-devkit/core';
 import * as child_process from 'child_process';
 import * as fs from 'fs';
-import * as glob from 'glob';
+import glob from 'glob';
 import * as path from 'path';
 import { packages } from '../lib/packages';
 import buildSchema from './build-schema';

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -8,7 +8,7 @@
 
 import { logging } from '@angular-devkit/core';
 import { execSync, spawnSync } from 'child_process';
-import * as glob from 'glob';
+import glob from 'glob';
 import { SpecReporter as JasmineSpecReporter, StacktraceOption } from 'jasmine-spec-reporter';
 import { ParsedArgs } from 'minimist';
 import { join, normalize, relative } from 'path';

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-server.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-server.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import express from 'express';
 import { join } from 'path';
 import { getGlobalVariable } from '../../utils/env';
 import { appendToFile, expectFileToMatch, writeFile } from '../../utils/fs';
@@ -22,7 +22,7 @@ export default async function () {
   await ng('add', '@nguniversal/express-engine@9.0.0-next.6', '--skip-install');
 
   if (isSnapshotBuild) {
-    await updateJsonFile('package.json', packageJson => {
+    await updateJsonFile('package.json', (packageJson) => {
       const dependencies = packageJson['dependencies'];
       dependencies['@angular/platform-server'] = snapshots.dependencies['@angular/platform-server'];
     });
@@ -34,7 +34,7 @@ export default async function () {
   const serverBuildArgs = ['run', 'test-project:server'];
 
   // Add server-specific config.
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appProject = workspaceJson.projects['test-project'];
     const appArchitect = appProject.architect || appProject.targets;
     const serverOptions = appArchitect['server'].options;
@@ -110,7 +110,9 @@ export default async function () {
 
     // Run the server
     const serverBundle = join(process.cwd(), `${serverbaseDir}/${lang}/main.js`);
-    const { i18nApp } = await import(serverBundle) as { i18nApp(locale: string): express.Express };
+    const { i18nApp } = (await import(serverBundle)) as {
+      i18nApp(locale: string): express.Express;
+    };
     const server = i18nApp(lang).listen(4200, 'localhost');
     try {
       // Execute without a devserver.

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-serviceworker.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-serviceworker.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import express from 'express';
 import { resolve } from 'path';
 import { getGlobalVariable } from '../../utils/env';
 import {
@@ -14,7 +14,7 @@ import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 import { readNgVersion } from '../../utils/version';
 
-export default async function() {
+export default async function () {
   // TEMP: disable pending i18n updates
   // TODO: when re-enabling, use setupI18nConfig and helpers like other i18n tests.
   return;
@@ -33,7 +33,7 @@ export default async function() {
   }
   await installPackage(serviceWorkerVersion);
 
-  await updateJsonFile('tsconfig.json', config => {
+  await updateJsonFile('tsconfig.json', (config) => {
     config.compilerOptions.target = 'es2015';
     if (!config.angularCompilerOptions) {
       config.angularCompilerOptions = {};
@@ -49,7 +49,7 @@ export default async function() {
     { lang: 'fr', translation: 'Bonjour i18n!' },
   ];
 
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appProject = workspaceJson.projects['test-project'];
     const appArchitect = appProject.architect || appProject.targets;
     const serveConfigs = appArchitect['serve'].configurations;

--- a/tests/legacy-cli/e2e/tests/misc/browsers.ts
+++ b/tests/legacy-cli/e2e/tests/misc/browsers.ts
@@ -1,7 +1,6 @@
-import * as express from 'express';
+import express from 'express';
 import * as path from 'path';
 import { copyProjectAsset } from '../../utils/assets';
-import { getGlobalVariable } from '../../utils/env';
 import { replaceInFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
@@ -15,18 +14,10 @@ export default async function () {
     throw new Error('SauceLabs is not configured.');
   }
 
-  await replaceInFile(
-    '.browserslistrc',
-    'not IE 11',
-    'IE 11',
-  );
+  await replaceInFile('.browserslistrc', 'not IE 11', 'IE 11');
 
   // Workaround for https://github.com/angular/angular/issues/32192
-  await replaceInFile(
-    'src/app/app.component.html',
-    /class="material-icons"/g,
-    '',
-  );
+  await replaceInFile('src/app/app.component.html', /class="material-icons"/g, '');
 
   await ng('build');
 

--- a/tests/legacy-cli/e2e/tests/misc/proxy-config.ts
+++ b/tests/legacy-cli/e2e/tests/misc/proxy-config.ts
@@ -1,14 +1,14 @@
-import * as express from 'express';
+import express from 'express';
 import * as http from 'http';
 
-import {writeFile} from '../../utils/fs';
-import {request} from '../../utils/http';
-import {killAllProcesses, ng} from '../../utils/process';
-import {ngServe} from '../../utils/project';
-import {updateJsonFile} from '../../utils/project';
-import {expectToFail} from "../../utils/utils";
+import { writeFile } from '../../utils/fs';
+import { request } from '../../utils/http';
+import { killAllProcesses, ng } from '../../utils/process';
+import { ngServe } from '../../utils/project';
+import { updateJsonFile } from '../../utils/project';
+import { expectToFail } from '../../utils/utils';
 
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   // Create an express app that serves as a proxy.
@@ -27,45 +27,59 @@ export default function() {
   const proxyConfigFile = 'proxy.config.json';
   const proxyConfig = {
     '/api/*': {
-      target: proxyServerUrl
-    }
+      target: proxyServerUrl,
+    },
   };
 
-  return Promise.resolve()
-    .then(() => writeFile(proxyConfigFile, JSON.stringify(proxyConfig, null, 2)))
-    .then(() => ngServe('--proxy-config', proxyConfigFile))
-    .then(() => request('http://localhost:4200/api/test'))
-    .then(body => {
-      if (!body.match(/TEST_API_RETURN/)) {
-        throw new Error('Response does not match expected value.');
-      }
-    })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
+  return (
+    Promise.resolve()
+      .then(() => writeFile(proxyConfigFile, JSON.stringify(proxyConfig, null, 2)))
+      .then(() => ngServe('--proxy-config', proxyConfigFile))
+      .then(() => request('http://localhost:4200/api/test'))
+      .then((body) => {
+        if (!body.match(/TEST_API_RETURN/)) {
+          throw new Error('Response does not match expected value.');
+        }
+      })
+      .then(
+        () => killAllProcesses(),
+        (err) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
 
-    // .then(() => updateJsonFile('angular.json', configJson => {
-    //   const app = configJson.defaults;
-    //   app.serve = {
-    //     proxyConfig: proxyConfigFile
-    //   };
-    // }))
-    // .then(() => ngServe())
-    // .then(() => request('http://localhost:4200/api/test'))
-    // .then(body => {
-    //   if (!body.match(/TEST_API_RETURN/)) {
-    //     throw new Error('Response does not match expected value.');
-    //   }
-    // })
-    // .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
+      // .then(() => updateJsonFile('angular.json', configJson => {
+      //   const app = configJson.defaults;
+      //   app.serve = {
+      //     proxyConfig: proxyConfigFile
+      //   };
+      // }))
+      // .then(() => ngServe())
+      // .then(() => request('http://localhost:4200/api/test'))
+      // .then(body => {
+      //   if (!body.match(/TEST_API_RETURN/)) {
+      //     throw new Error('Response does not match expected value.');
+      //   }
+      // })
+      // .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
 
-    .then(() => server.close(), (err) => { server.close(); throw err; })
+      .then(
+        () => server.close(),
+        (err) => {
+          server.close();
+          throw err;
+        },
+      )
+  );
 
-    // // A non-existing proxy file should error.
-    // .then(() => expectToFail(() => ng('serve', '--proxy-config', 'proxy.non-existent.json')))
-    // .then(() => updateJsonFile('angular.json', configJson => {
-    //   const app = configJson.defaults;
-    //   app.serve = {
-    //     proxyConfig: 'proxy.non-existent.json'
-    //   };
-    // }))
-    // .then(() => expectToFail(() => ng('serve')));
+  // // A non-existing proxy file should error.
+  // .then(() => expectToFail(() => ng('serve', '--proxy-config', 'proxy.non-existent.json')))
+  // .then(() => updateJsonFile('angular.json', configJson => {
+  //   const app = configJson.defaults;
+  //   app.serve = {
+  //     proxyConfig: 'proxy.non-existent.json'
+  //   };
+  // }))
+  // .then(() => expectToFail(() => ng('serve')));
 }

--- a/tests/legacy-cli/e2e/tests/misc/public-host.ts
+++ b/tests/legacy-cli/e2e/tests/misc/public-host.ts
@@ -1,5 +1,4 @@
 import * as os from 'os';
-import * as _ from 'lodash';
 
 import { request } from '../../utils/http';
 import { killAllProcesses } from '../../utils/process';
@@ -8,56 +7,81 @@ import { ngServe } from '../../utils/project';
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
-  const firstLocalIp = _(os.networkInterfaces())
-    .values()
-    .flatten()
-    .filter({ family: 'IPv4', internal: false })
-    .map('address')
-    .first();
+  const firstLocalIp = Object.values(os.networkInterfaces())
+    .flat()
+    .filter((ni) => ni.family === 'IPv4' && !ni.internal)
+    .map((ni) => ni.address)
+    .shift();
   const publicHost = `${firstLocalIp}:4200`;
   const localAddress = `http://${publicHost}`;
 
-  return Promise.resolve()
-    // Disabling this test. Webpack Dev Server does not check the hots anymore when binding to
-    // numeric IP addresses.
-    // .then(() => ngServe('--host=0.0.0.0'))
-    // .then(() => request(localAddress))
-    // .then(body => {
-    //   if (!body.match(/Invalid Host header/)) {
-    //     throw new Error('Response does not match expected value.');
-    //   }
-    // })
-    // .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
-    .then(() => ngServe('--host=0.0.0.0', `--public-host=${publicHost}`))
-    .then(() => request(localAddress))
-    .then(body => {
-      if (!body.match(/<app-root><\/app-root>/)) {
-        throw new Error('Response does not match expected value.');
-      }
-    })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
-    .then(() => ngServe('--host=0.0.0.0', `--disable-host-check`))
-    .then(() => request(localAddress))
-    .then(body => {
-      if (!body.match(/<app-root><\/app-root>/)) {
-        throw new Error('Response does not match expected value.');
-      }
-    })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
-    .then(() => ngServe('--host=0.0.0.0', `--public-host=${localAddress}`))
-    .then(() => request(localAddress))
-    .then(body => {
-      if (!body.match(/<app-root><\/app-root>/)) {
-        throw new Error('Response does not match expected value.');
-      }
-    })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
-    .then(() => ngServe('--host=0.0.0.0', `--public-host=${firstLocalIp}`))
-    .then(() => request(localAddress))
-    .then(body => {
-      if (!body.match(/<app-root><\/app-root>/)) {
-        throw new Error('Response does not match expected value.');
-      }
-    })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; });
+  return (
+    Promise.resolve()
+      // Disabling this test. Webpack Dev Server does not check the hots anymore when binding to
+      // numeric IP addresses.
+      // .then(() => ngServe('--host=0.0.0.0'))
+      // .then(() => request(localAddress))
+      // .then(body => {
+      //   if (!body.match(/Invalid Host header/)) {
+      //     throw new Error('Response does not match expected value.');
+      //   }
+      // })
+      // .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
+      .then(() => ngServe('--host=0.0.0.0', `--public-host=${publicHost}`))
+      .then(() => request(localAddress))
+      .then((body) => {
+        if (!body.match(/<app-root><\/app-root>/)) {
+          throw new Error('Response does not match expected value.');
+        }
+      })
+      .then(
+        () => killAllProcesses(),
+        (err) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+      .then(() => ngServe('--host=0.0.0.0', `--disable-host-check`))
+      .then(() => request(localAddress))
+      .then((body) => {
+        if (!body.match(/<app-root><\/app-root>/)) {
+          throw new Error('Response does not match expected value.');
+        }
+      })
+      .then(
+        () => killAllProcesses(),
+        (err) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+      .then(() => ngServe('--host=0.0.0.0', `--public-host=${localAddress}`))
+      .then(() => request(localAddress))
+      .then((body) => {
+        if (!body.match(/<app-root><\/app-root>/)) {
+          throw new Error('Response does not match expected value.');
+        }
+      })
+      .then(
+        () => killAllProcesses(),
+        (err) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+      .then(() => ngServe('--host=0.0.0.0', `--public-host=${firstLocalIp}`))
+      .then(() => request(localAddress))
+      .then((body) => {
+        if (!body.match(/<app-root><\/app-root>/)) {
+          throw new Error('Response does not match expected value.');
+        }
+      })
+      .then(
+        () => killAllProcesses(),
+        (err) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+  );
 }

--- a/tests/legacy-cli/e2e/utils/assets.ts
+++ b/tests/legacy-cli/e2e/utils/assets.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import * as glob from 'glob';
+import glob from 'glob';
 import { getGlobalVariable } from './env';
 import { relative, resolve } from 'path';
 import { copyFile, writeFile } from './fs';

--- a/tests/legacy-cli/e2e/utils/http.ts
+++ b/tests/legacy-cli/e2e/utils/http.ts
@@ -1,13 +1,12 @@
-import {IncomingMessage} from 'http';
-import * as _request from 'request';
-
+import { IncomingMessage } from 'http';
+import _request from 'request';
 
 export function request(url: string): Promise<string> {
   return new Promise((resolve, reject) => {
     let options = {
       url: url,
       headers: { 'Accept': 'text/html' },
-      agentOptions: { rejectUnauthorized: false }
+      agentOptions: { rejectUnauthorized: false },
     };
     _request(options, (error: any, response: IncomingMessage, body: string) => {
       if (error) {

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -5,8 +5,8 @@ import { createConsoleLogger } from '@angular-devkit/core/node';
 import * as colors from 'ansi-colors';
 import { spawn } from 'child_process';
 import * as fs from 'fs';
-import * as glob from 'glob';
-import * as minimist from 'minimist';
+import glob from 'glob';
+import minimist from 'minimist';
 import * as os from 'os';
 import * as path from 'path';
 import { setGlobalVariable } from './e2e/utils/env';
@@ -57,11 +57,11 @@ const argv = minimist(process.argv.slice(2), {
 process.exitCode = 255;
 
 const logger = createConsoleLogger(argv.verbose, process.stdout, process.stderr, {
-  info: s => s,
-  debug: s => s,
-  warn: s => colors.bold.yellow(s),
-  error: s => colors.bold.red(s),
-  fatal: s => colors.bold.red(s),
+  info: (s) => s,
+  debug: (s) => s,
+  warn: (s) => colors.bold.yellow(s),
+  error: (s) => colors.bold.red(s),
+  fatal: (s) => colors.bold.red(s),
 });
 
 const logStack = [logger];
@@ -75,25 +75,25 @@ let currentFileName = null;
 const e2eRoot = path.join(__dirname, 'e2e');
 const allSetups = glob
   .sync(path.join(e2eRoot, 'setup/**/*.ts'), { nodir: true })
-  .map(name => path.relative(e2eRoot, name))
+  .map((name) => path.relative(e2eRoot, name))
   .sort();
 const allTests = glob
   .sync(path.join(e2eRoot, testGlob), { nodir: true, ignore: argv.ignore })
-  .map(name => path.relative(e2eRoot, name))
+  .map((name) => path.relative(e2eRoot, name))
   // Replace windows slashes.
-  .map(name => name.replace(/\\/g, '/'))
+  .map((name) => name.replace(/\\/g, '/'))
   .sort()
-  .filter(name => !name.endsWith('/setup.ts'));
+  .filter((name) => !name.endsWith('/setup.ts'));
 
 const shardId = 'shard' in argv ? argv['shard'] : null;
 const nbShards = (shardId === null ? 1 : argv['nb-shards']) || 2;
-const tests = allTests.filter(name => {
+const tests = allTests.filter((name) => {
   // Check for naming tests on command line.
   if (argv._.length == 0) {
     return true;
   }
 
-  return argv._.some(argName => {
+  return argv._.some((argName) => {
     return (
       path.join(process.cwd(), argName) == path.join(__dirname, 'e2e', name) ||
       argName == name ||
@@ -128,12 +128,10 @@ setGlobalVariable('package-manager', argv.yarn ? 'yarn' : 'npm');
 setGlobalVariable('package-registry', 'http://localhost:4873');
 
 // Setup local package registry
-const registryPath =
-  fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'angular-cli-e2e-registry-'));
-fs.copyFileSync(
-  path.join(__dirname, 'verdaccio.yaml'),
-  path.join(registryPath, 'verdaccio.yaml'),
+const registryPath = fs.mkdtempSync(
+  path.join(fs.realpathSync(os.tmpdir()), 'angular-cli-e2e-registry-'),
 );
+fs.copyFileSync(path.join(__dirname, 'verdaccio.yaml'), path.join(registryPath, 'verdaccio.yaml'));
 const registryProcess = spawn(
   'node',
   [require.resolve('verdaccio/bin/verdaccio'), '-c', './verdaccio.yaml'],
@@ -172,7 +170,7 @@ testsToRun
         .then(() => fn(() => (clean = false)))
         .then(
           () => logStack.pop(),
-          err => {
+          (err) => {
             logStack.pop();
             throw err;
           },
@@ -193,7 +191,7 @@ testsToRun
 
             return gitClean().then(
               () => logStack.pop(),
-              err => {
+              (err) => {
                 logStack.pop();
                 throw err;
               },
@@ -202,7 +200,7 @@ testsToRun
         })
         .then(
           () => printFooter(currentFileName, start),
-          err => {
+          (err) => {
             printFooter(currentFileName, start);
             console.error(err);
             throw err;
@@ -219,7 +217,7 @@ testsToRun
       console.log(colors.green('Done.'));
       process.exit(0);
     },
-    err => {
+    (err) => {
       console.log('\n');
       console.error(colors.red(`Test "${currentFileName}" failed...`));
       console.error(colors.red(err.message));
@@ -251,8 +249,12 @@ function printHeader(testName: string, testIndex: number) {
       : (testIndex - allSetups.length) * nbShards + shardId + allSetups.length) + 1;
   const length = tests.length + allSetups.length;
   const shard =
-    shardId === null ? '' : colors.yellow(` [${shardId}:${nbShards}]` + colors.bold(` (${fullIndex}/${length})`));
-  console.log(colors.green(`Running "${colors.bold.blue(testName)}" (${colors.bold.white(text)}${shard})...`));
+    shardId === null
+      ? ''
+      : colors.yellow(` [${shardId}:${nbShards}]` + colors.bold(` (${fullIndex}/${length})`));
+  console.log(
+    colors.green(`Running "${colors.bold.blue(testName)}" (${colors.bold.white(text)}${shard})...`),
+  );
 }
 
 function printFooter(testName: string, startTime: number) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
The `esModuleInterop` option is recommended to be enable by TypeScript and corrects several assumptions TypeScript would otherwise make when importing CommonJS files.
This option change helps ensure compatibility as packages move towards ESM.
Reference: https://www.typescriptlang.org/tsconfig#esModuleInterop